### PR TITLE
Add switch for BASIC Auth.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - NGINX_CREDENTIALS=hoge:fuga      
       # Internal access via SSL termination on OAuth2_proxy.
       - NGINX_URL_SCHEME=http
+      - BASIC_AUTH=no
     ports:
       - "80:80"
       - "443:443"

--- a/nginx/config/entrypoint.sh
+++ b/nginx/config/entrypoint.sh
@@ -52,7 +52,7 @@ NGINX_TLS_PARAMS="ssl http2"
 
 echo "Configuring NGINX"
 
-if [[ $NGINX_PORT != 443 ]]; then unset NGINX_TLS_PARAMS ;fi
+[[ $NGINX_PORT != 443 ]] && unset NGINX_TLS_PARAMS
 
 if [[ $NGINX_PORT != 80 ]]; then
   cat > /etc/nginx/conf.d/default.conf <<EOF
@@ -65,6 +65,9 @@ server {
 EOF
 fi
 
+COMMENT_OUT=''
+[[ $BASIC_AUTH == 'no' ]] && COMMENT_OUT='#'
+
 cat >> /etc/nginx/conf.d/default.conf <<EOF
 server {
     listen ${NGINX_PORT} default_server ${NGINX_TLS_PARAMS};
@@ -72,7 +75,7 @@ server {
     ssl_certificate /etc/nginx/conf.d/ssl/certs/kibana-access.pem;
     ssl_certificate_key /etc/nginx/conf.d/ssl/private/kibana-access.key;
     location / {
-        auth_basic "Restricted";
+        ${COMMENT_OUT}auth_basic "Restricted";
         auth_basic_user_file /etc/nginx/conf.d/kibana.htpasswd;
         proxy_pass http://${KIBANA_HOST}/;
         proxy_buffer_size          128k;


### PR DESCRIPTION
- Become to control the BASIC Auth.
- Recommended use to either OAuth2, relevant it, or SAML than BASIC
  Auth.